### PR TITLE
wget execution fixes

### DIFF
--- a/switchGPU.sh
+++ b/switchGPU.sh
@@ -23,7 +23,7 @@ function get_gfx () {
 	set -e
 	rm -f $bin/done-gfx
 	echo "Fetching gfxCardStatus into $bin ..." >> $logfile
-	/usr/local/bin/wget -q "$url_gfx" -P $tmp
+	wget --no-check-certificate -q "$url_gfx" -P $tmp
 	[[ -d $bin/gfxCardStatus.app ]] && rm -rf $bin/gfxCardStatus.app
 	tar -C $bin -zxf $tmp/gfxCardStatus.tgz
 	rm -f $tmp/gfxCardStatus.tgz


### PR DESCRIPTION
Removes the full path to wget, since it doesn’t necessarily have to be
located under /usr/local/bin. It also adds the --no-check-certificate
parameter to that same command to avoid SSL/TLS certificate checking
errors.
